### PR TITLE
Make private traits used in bounds public

### DIFF
--- a/src/func.rs
+++ b/src/func.rs
@@ -54,7 +54,6 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Range, Rem, Sub, SubAs
 ///
 /// This is slightly more optimized than the iterator version, but uses internal iteration. Unlike
 /// the iterator version, vertical and horizontal lines will always be traversed in an ascending order.
-#[allow(private_bounds)]
 pub fn clipline<T, F>(
     line: (Point<T>, Point<T>),
     clip_rect: (Point<T>, Point<T>),

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,9 +1,10 @@
-use crate::util::{
-    bresenham_step, clip_rect_entry, clip_rect_exit, destandardize, standardize, Constant, Point,
-};
 use core::cmp::{max, min};
 use core::iter::FusedIterator;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
+
+use crate::util::{
+    bresenham_step, clip_rect_entry, clip_rect_exit, destandardize, standardize, Constant, Point,
+};
 
 /// Enum representing the different variants of clipped line segment iterators.
 ///
@@ -165,7 +166,6 @@ struct Bresenham<T> {
     term: T,
 }
 
-#[allow(private_bounds)]
 impl<T> Clipline<T>
 where
     T: Copy
@@ -235,7 +235,6 @@ where
     }
 }
 
-#[allow(private_bounds)]
 impl<T> Vlipline<T>
 where
     T: Ord + Neg<Output = T> + Constant<Output = T>,
@@ -288,7 +287,6 @@ where
     }
 }
 
-#[allow(private_bounds)]
 impl<T> Hlipline<T>
 where
     T: Ord + Neg<Output = T> + Constant<Output = T>,
@@ -694,8 +692,8 @@ where
 // -----------------------------------------------
 
 /// The absolute difference operation.
-trait AbsDiff<Rhs = Self> {
-    /// The resulting type after applying the `+` operator.
+pub trait AbsDiff<Rhs = Self> {
+    /// The resulting type after applying the `abs_diff` operation.
     type Output;
 
     /// Computes the absolute difference between `self` and `other`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,4 +22,6 @@ mod util;
 #[cfg(feature = "func")]
 pub use func::clipline;
 #[cfg(feature = "iter")]
-pub use iter::{Clipline, Gentleham, Hlipline, Steepnham, Vlipline};
+pub use iter::{AbsDiff, Clipline, Gentleham, Hlipline, Steepnham, Vlipline};
+#[cfg(any(feature = "func", feature = "iter"))]
+pub use util::Constant;

--- a/src/util.rs
+++ b/src/util.rs
@@ -209,7 +209,8 @@ where
     (err, xyd, yxd)
 }
 
-pub(crate) trait Constant {
+/// Provides constants for `0`, `1` and `2`.
+pub trait Constant {
     type Output;
 
     const ZERO: Self::Output;


### PR DESCRIPTION
Should fix the compile error involving private traits in a public API. For some reason, I didn't get that error when using the library in my other project.